### PR TITLE
improvements to template loading and dynamic setup of renderer

### DIFF
--- a/_examples/basic/index.html
+++ b/_examples/basic/index.html
@@ -11,6 +11,7 @@
         {{template "nav"}}
         <h1>Hello {{.Name}}!!</h1>
         {{ template "content" . }}
+        <p>Click <a href="./content">here</a> to render only the content template</p>
     </body>
 
 </html>

--- a/_examples/basic/index.html
+++ b/_examples/basic/index.html
@@ -10,7 +10,11 @@
     <body>
         {{template "nav"}}
         <h1>Hello {{.Name}}!!</h1>
-        <p>{{.Content}}</p>
+        {{ template "content" . }}
     </body>
 
 </html>
+
+{{ define "content" }}
+<p>{{.Content}}</p>
+{{ end }}

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -11,25 +11,35 @@ import (
 )
 
 // Sets the configuration for the renderer
-var ropts = loadr.RendererOpts{
-	FS:          os.DirFS("."),
-	StripPrefix: "",
-	// setting livereload to true allows the app to be built once, and then you can update the HTML and simply refresh the page
-	LiveReload: true,
+func getRenderOpts() loadr.RendererOpts {
+	return loadr.RendererOpts{
+		FS:          os.DirFS("."),
+		StripPrefix: "pages",
+		LiveReload:  true,
+	}
 }
 
 // This creates a base component with predefined fragments
 // using the html/template
-var baseWithComponents = loadr.NewRenderer(ropts).WithComponents("global_components.html")
+var baseWithComponents = loadr.NewRenderer(getRenderOpts()).WithComponents("global_components.html")
 
 // Using the base component, index.html is loaded in
 // We have now created our index component where it will
 // the variable should always be lowercased
-var index = baseWithComponents.LoadPages("index.html")
+var index = baseWithComponents.LoadFiles("index.html")
+
+// From the .html file we extract the templates
+
+// Using no template name, equivalent to calling Execute on a parsed template file
+var indexPage = index.Template(loadr.NoTemplateName)
+
+// To render only a named template
+var indexContent = index.Template("content")
 
 // The defined data that the render function takes in
 type IndexData struct {
-	Name string
+	Name    string
+	Content string
 }
 
 // This is the render function where the HTML rendering and custom data model come together
@@ -39,7 +49,11 @@ type IndexData struct {
 // If false, the cached version will be used instead
 // check out the benchmark (here:) to see the performance difference
 func RenderIndex(w io.Writer, d IndexData) error {
-	return index.Render(w, d)
+	return indexPage.Render(w, d)
+}
+
+func RenderIndexContent(w io.Writer, d IndexData) error {
+	return indexContent.Render(w, d)
 }
 
 // Uncomment the line below and see how the program will fail immediately on start
@@ -51,7 +65,11 @@ func main() {
 
 	// The rendering is called in here
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		RenderIndex(w, IndexData{"Bob"})
+		RenderIndex(w, IndexData{"Bob", "SomeContent"})
+	})
+
+	r.HandleFunc("/content", func(w http.ResponseWriter, r *http.Request) {
+		RenderIndexContent(w, IndexData{"Bob", "SomeContent"})
 	})
 
 	fmt.Println("Listening on 8080, open http://localhost:8080/")

--- a/loadr.go
+++ b/loadr.go
@@ -2,6 +2,7 @@ package loadr
 
 import (
 	"errors"
+	"fmt"
 	"html/template"
 	"io"
 	"io/fs"
@@ -14,19 +15,32 @@ type RendererOpts struct {
 	LiveReload  bool   // Enables/disables template reloading on every render
 }
 
-// Composes the std template and keeps track of the existing patterns
-type TemplateRender struct {
-	template    *template.Template
-	patterns    []string
-	liveReload  bool
-	fs          fs.FS
-	stripPrefix string
+// Renderer with a set of options and components
+type Renderer struct {
+	opts       RendererOpts
+	components []string
+}
+
+// Represents a loaded file contianing templates
+type TemplateFile struct {
+	patterns         []string
+	templates        map[string]*template.Template
+	opts             RendererOpts
+	topLevelTemplate *template.Template
+}
+
+// Individual template to be rendered
+type Template struct {
+	template   *template.Template
+	name       string
+	patterns   []string
+	liveReload bool
+	fs         fs.FS
 }
 
 // Helper function to parse new pages
 // Function will panic on error
-func NewRenderer(r RendererOpts) *TemplateRender {
-
+func NewRenderer(r RendererOpts) *Renderer {
 	if r.StripPrefix == "" {
 		r.StripPrefix = "."
 	}
@@ -41,44 +55,74 @@ func NewRenderer(r RendererOpts) *TemplateRender {
 		panic("filesystem not set for HTML renderer")
 	}
 
-	return &TemplateRender{
-		fs:          r.FS,
-		stripPrefix: r.StripPrefix,
-		liveReload:  r.LiveReload,
+	return &Renderer{
+		opts: r,
 	}
 }
 
-// Clones and loads in the pages to be rendered out
-func (t TemplateRender) LoadPages(pages ...string) *TemplateRender {
-	t.patterns = append(pages, t.patterns...) // Order is important here
-	t.template = template.Must(template.ParseFS(t.fs, t.patterns...))
-	return &t
-}
-
-// Clones and reloads the existing pages
-func (t TemplateRender) ReloadPages() *TemplateRender {
-	t.template = template.Must(template.ParseFS(t.fs, t.patterns...))
-	return &t
-}
-
 // Clones and adds the relevant components
-func (t TemplateRender) WithComponents(commonComponents ...string) *TemplateRender {
-	t.patterns = append(t.patterns, commonComponents...)
+func (r Renderer) WithComponents(commonComponents ...string) *Renderer {
+	r.components = append(r.components, commonComponents...)
+	return &r
+}
+
+// Load in a group of files containing templates
+func (r Renderer) LoadFiles(pages ...string) *TemplateFile {
+	var file TemplateFile
+	file.opts = r.opts
+	file.patterns = r.components
+	file.patterns = append(pages, file.patterns...)
+	file.topLevelTemplate = template.Must(template.ParseFS(r.opts.FS, file.patterns...))
+
+	file.templates = make(map[string]*template.Template)
+	for _, subTmpl := range file.topLevelTemplate.Templates() {
+		file.templates[subTmpl.Name()] = subTmpl
+	}
+	return &file
+}
+
+const NoTemplateName string = ""
+
+func (f TemplateFile) Template(name string) *Template {
+	var t Template
+	t.fs = f.opts.FS
+	t.liveReload = f.opts.LiveReload
+	t.patterns = f.patterns
+	t.name = name
+	if name == NoTemplateName {
+		t.name = f.topLevelTemplate.Name()
+		t.template = f.topLevelTemplate
+		return &t
+	}
+	var ok bool
+	t.template, ok = f.templates[t.name]
+	if !ok {
+		panic(fmt.Sprintf("template %s not found", name))
+	}
 	return &t
 }
 
 var ErrTemplateNotYetParsed = errors.New("the template has not yet been parsed. Did you run LoadPages or ReloadPages?")
 
+// Clones and reloads the existing template
+func (t Template) ReloadTemplate() *Template {
+	name := t.name
+	t.template = template.Must(template.ParseFS(t.fs, t.patterns...))
+	if t.name != NoTemplateName {
+		t.template = t.template.Lookup(name)
+	}
+	return &t
+}
+
 // Given the data, and the liveReload flag renders the HTML
-// If the live reload flag is true, the pages will first be reloaded then rendered again
-func (t *TemplateRender) Render(wr io.Writer, data any) error {
+// If the live reload flag is set, the pages will first be reloaded then rendered again
+func (t *Template) Render(wr io.Writer, data any) error {
 	if t.liveReload {
-		t = t.ReloadPages()
+		t = t.ReloadTemplate()
 	}
 
 	if t.template == nil {
 		return ErrTemplateNotYetParsed
 	}
-
 	return t.template.Execute(wr, data)
 }

--- a/performance_test.go
+++ b/performance_test.go
@@ -15,7 +15,7 @@ func BenchmarkWithReload(b *testing.B) {
 		LiveReload:  true,
 	}
 
-	r := NewRenderer(ropts).WithComponents("global_components.html").LoadPages("index.html")
+	r := NewRenderer(ropts).WithComponents("global_components.html").LoadFiles("index.html").Template(NoTemplateName)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -33,7 +33,42 @@ func BenchmarkNoReload(b *testing.B) {
 		LiveReload:  false,
 	}
 
-	r := NewRenderer(ropts).WithComponents("global_components.html").LoadPages("index.html")
+	r := NewRenderer(ropts).WithComponents("global_components.html").LoadFiles("index.html").Template(NoTemplateName)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var bs bytes.Buffer
+		r.Render(&bs, nil)
+	}
+}
+
+func BenchmarkNamedWithReload(b *testing.B) {
+
+	var ropts = RendererOpts{
+		FS:          os.DirFS("./_examples/basic"),
+		StripPrefix: "",
+		LiveReload:  true,
+	}
+
+	r := NewRenderer(ropts).WithComponents("global_components.html").LoadFiles("index.html").Template("content")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var bs bytes.Buffer
+		r.Render(&bs, nil)
+	}
+}
+
+// With parsing being cached
+func BenchmarkNamedNoReload(b *testing.B) {
+
+	var ropts = RendererOpts{
+		FS:          os.DirFS("./_examples/basic/"),
+		StripPrefix: "",
+		LiveReload:  false,
+	}
+
+	r := NewRenderer(ropts).WithComponents("global_components.html").LoadFiles("index.html").Template("content")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/performance_test.go
+++ b/performance_test.go
@@ -15,12 +15,13 @@ func BenchmarkWithReload(b *testing.B) {
 		LiveReload:  true,
 	}
 
-	r := NewRenderer(ropts).WithComponents("global_components.html").LoadFiles("index.html").Template(NoTemplateName)
-
+	r := NewRenderer().WithComponents("global_components.html")
+	t := r.LoadFiles("index.html").Template(NoTemplateName)
+	r.SetOptions(ropts)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var bs bytes.Buffer
-		r.Render(&bs, nil)
+		t.Render(&bs, nil)
 	}
 }
 
@@ -33,16 +34,18 @@ func BenchmarkNoReload(b *testing.B) {
 		LiveReload:  false,
 	}
 
-	r := NewRenderer(ropts).WithComponents("global_components.html").LoadFiles("index.html").Template(NoTemplateName)
-
+	r := NewRenderer().WithComponents("global_components.html")
+	t := r.LoadFiles("index.html").Template(NoTemplateName)
+	r.SetOptions(ropts)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var bs bytes.Buffer
-		r.Render(&bs, nil)
+		t.Render(&bs, nil)
 	}
 }
 
-func BenchmarkNamedWithReload(b *testing.B) {
+// Same as above but with named templates
+func BenchmarkNamedTemplateReload(b *testing.B) {
 
 	var ropts = RendererOpts{
 		FS:          os.DirFS("./_examples/basic"),
@@ -50,17 +53,17 @@ func BenchmarkNamedWithReload(b *testing.B) {
 		LiveReload:  true,
 	}
 
-	r := NewRenderer(ropts).WithComponents("global_components.html").LoadFiles("index.html").Template("content")
-
+	r := NewRenderer().WithComponents("global_components.html")
+	t := r.LoadFiles("index.html").Template("content")
+	r.SetOptions(ropts)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var bs bytes.Buffer
-		r.Render(&bs, nil)
+		t.Render(&bs, nil)
 	}
 }
 
-// With parsing being cached
-func BenchmarkNamedNoReload(b *testing.B) {
+func BenchmarkNamedTemplateNoReload(b *testing.B) {
 
 	var ropts = RendererOpts{
 		FS:          os.DirFS("./_examples/basic/"),
@@ -68,11 +71,12 @@ func BenchmarkNamedNoReload(b *testing.B) {
 		LiveReload:  false,
 	}
 
-	r := NewRenderer(ropts).WithComponents("global_components.html").LoadFiles("index.html").Template("content")
-
+	r := NewRenderer().WithComponents("global_components.html")
+	t := r.LoadFiles("index.html").Template("content")
+	r.SetOptions(ropts)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var bs bytes.Buffer
-		r.Render(&bs, nil)
+		t.Render(&bs, nil)
 	}
 }


### PR DESCRIPTION
Added ability to render a named template within a file

Files and templates are now stored as file patterns and only loaded once the options are set on a renderer, allowing options to be set in or after main function instead of at package init.
Use case of using flag to alter livereload provided in examples (parsing flags will not work at package init)
Fast fail still statisfied except for case where options not set which fails on any render call